### PR TITLE
Fix Content-type value on POST (and other methods != GET)

### DIFF
--- a/VisualJSON/VJDocument.m
+++ b/VisualJSON/VJDocument.m
@@ -377,6 +377,7 @@
         
         if (self.method && ![self.method isEqualToString:@"GET"]) {
             [req setHTTPMethod:self.method];
+            [req setValue:@"application/x-www-form-urlencoded" forHTTPHeaderField:@"Content-type"];
             [req setHTTPBody:self.querydata.dataUsingUTF8Encoding];
         }
         


### PR DESCRIPTION
Fixes sending the wrong Content-Type header by removing the
application/json value it was wrongly setting by default. Only
application/x-www-form-urlencoded is now sent, so the server can
interpret the HTTP body accordingly.
